### PR TITLE
indent YAML lists (aka sequences)

### DIFF
--- a/cogreqs/types.py
+++ b/cogreqs/types.py
@@ -134,6 +134,7 @@ Reference: https://github.com/replicate/cog/blob/main/docs/yaml.md
         """
         yaml = YAML()
         yaml.preserve_quotes = True
+        yaml.indent(mapping=2, sequence=4, offset=2)
         yaml.representer.add_representer(list, list_representer)
         s = StringIO()
         yaml.dump(self.to_yaml_dict(), s)


### PR DESCRIPTION
This is definitely a matter of personal preference, but I've always found it a bit confusing to see YAML lists where the hyphenated items are not indented.

A cursory search of [existing `cog.yaml` files on GitHub](https://github.com/search?q=filename%3Acog.yaml&type=code) shows that others tend to prefer this indented syntax, too.

Confusing:

```yaml
python_packages:
- "matplotlib==3.5.1"
- "numpy==1.22.2"
- "Pillow==9.0.1"
- "scikit_learn==1.0.2"
```

Clear:

```yaml
python_packages:
  - "matplotlib==3.5.1"
  - "numpy==1.22.2"
  - "Pillow==9.0.1"
  - "scikit_learn==1.0.2"
```

This PR changes the YAML dumper to indent these lists.

---

From https://yaml.readthedocs.io/en/latest/detail.html

<img width="673" alt="Screen Shot 2022-02-18 at 2 20 54 PM" src="https://user-images.githubusercontent.com/2289/154768985-e8a7e1a0-6e72-4e66-bfa2-0577b1f29fc2.png">

cc @andreasjansson 